### PR TITLE
Set `ember-source` dependency to `null` for bower scenarios

### DIFF
--- a/lib/auto-scenario-config-for-ember.js
+++ b/lib/auto-scenario-config-for-ember.js
@@ -31,6 +31,11 @@ function generateScenariosFromSemver(semverStatements, availableVersions) {
           dependencies: {
             ember: versionNum
           }
+        },
+        npm: {
+          devDependencies: {
+            'ember-source': null
+          }
         }
       };
     });
@@ -55,6 +60,11 @@ function baseScenarios() {
         resolutions: {
           ember: 'beta'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -66,6 +76,11 @@ function baseScenarios() {
         },
         resolutions: {
           ember: 'canary'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     }

--- a/test/auto-scenario-config-for-ember-test.js
+++ b/test/auto-scenario-config-for-ember-test.js
@@ -26,6 +26,11 @@ describe('lib/auto-scenario-config-for-ember', function() {
             resolutions: {
               ember: 'beta'
             }
+          },
+          npm: {
+            devDependencies: {
+              'ember-source': null
+            }
           }
         },
         {
@@ -38,6 +43,11 @@ describe('lib/auto-scenario-config-for-ember', function() {
             resolutions: {
               ember: 'canary'
             }
+          },
+          npm: {
+            devDependencies: {
+              'ember-source': null
+            }
           }
         },
         {
@@ -45,6 +55,11 @@ describe('lib/auto-scenario-config-for-ember', function() {
           bower: {
             dependencies: {
               ember: '2.0.0'
+            }
+          },
+          npm: {
+            devDependencies: {
+              'ember-source': null
             }
           }
         }
@@ -72,13 +87,13 @@ describe('lib/auto-scenario-config-for-ember', function() {
     return autoScenarioConfigForEmber({ versionCompatibility: { ember: '1.0.5 - 1.0.15 || >= 2.1.0 || ^1.11.0 || 1.1.0 - 2.0.0' }, availableVersions: availableVersions }).then(function(config) {
       expect(config.scenarios).to.deep.include.members(
         [
-          { name: 'ember-1.0.15', bower: { dependencies: { ember: '1.0.15' } } },
-          { name: 'ember-1.1.3', bower: { dependencies: { ember: '1.1.3' } } },
-          { name: 'ember-2.0.0', bower: { dependencies: { ember: '2.0.0' } } },
-          { name: 'ember-1.13.0', bower: { dependencies: { ember: '1.13.0' } } },
-          { name: 'ember-2.1.1', bower: { dependencies: { ember: '2.1.1' } } },
-          { name: 'ember-3.0.0', bower: { dependencies: { ember: '3.0.0' } } },
-          { name: 'ember-1.11.14', bower: { dependencies: { ember: '1.11.14' } } }
+          { name: 'ember-1.0.15', bower: { dependencies: { ember: '1.0.15' } }, npm: { devDependencies: { 'ember-source': null } } },
+          { name: 'ember-1.1.3', bower: { dependencies: { ember: '1.1.3' } }, npm: { devDependencies: { 'ember-source': null } } },
+          { name: 'ember-2.0.0', bower: { dependencies: { ember: '2.0.0' } }, npm: { devDependencies: { 'ember-source': null } } },
+          { name: 'ember-1.13.0', bower: { dependencies: { ember: '1.13.0' } }, npm: { devDependencies: { 'ember-source': null } } },
+          { name: 'ember-2.1.1', bower: { dependencies: { ember: '2.1.1' } }, npm: { devDependencies: { 'ember-source': null } } },
+          { name: 'ember-3.0.0', bower: { dependencies: { ember: '3.0.0' } }, npm: { devDependencies: { 'ember-source': null } } },
+          { name: 'ember-1.11.14', bower: { dependencies: { ember: '1.11.14' } }, npm: { devDependencies: { 'ember-source': null } } }
         ]
       );
     });


### PR DESCRIPTION
Resolves #14 

This should probably be backported to v1.x once merged so that older Ember CLI releases can take advantage of this.