### PR TITLE
Added onlyVersionCompatibility to generateConfig

### DIFF
--- a/lib/auto-scenario-config-for-ember.js
+++ b/lib/auto-scenario-config-for-ember.js
@@ -6,13 +6,26 @@ let getChannelURL = require('ember-source-channel-url');
 const firstEmberSourceVersion = '2.11.0';
 
 module.exports = async function generateConfig(options) {
-  let [base, semver] = await Promise.all([
-    generateBaseScenarios(options.getChannelURL),
-    generateScenariosFromSemver(options.versionCompatibility, options.availableVersions),
-  ]);
+  let versionPromises;
+
+  if (options.onlyVersionCompatibility) {
+    versionPromises = [
+      //resolves requested versions
+      generateScenariosFromSemver(options.versionCompatibility, options.availableVersions),
+    ];
+  } else {
+    versionPromises = [
+      //always resolves beta, canary, release
+      generateBaseScenarios(options.getChannelURL),
+      //resolves requested versions
+      generateScenariosFromSemver(options.versionCompatibility, options.availableVersions),
+    ];
+  }
+
+  let versions = await Promise.all(versionPromises);
 
   return {
-    scenarios: [...base, ...semver],
+    scenarios: versions.reduce((acc, v) => [...acc, ...v], []),
   };
 };
 

--- a/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
+++ b/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/auto-scenario-config-for-ember returns only requested versions 1`] = `
+Array [
+  Object {
+    "name": "ember-2.11.0",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "2.11.0",
+      },
+    },
+  },
+  Object {
+    "name": "ember-2.12.2",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "2.12.2",
+      },
+    },
+  },
+  Object {
+    "name": "ember-2.18.0",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "2.18.0",
+      },
+    },
+  },
+  Object {
+    "name": "ember-3.1.1",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "3.1.1",
+      },
+    },
+  },
+]
+`;
+
 exports[`lib/auto-scenario-config-for-ember works with complex semver statement 1`] = `
 Array [
   Object {

--- a/test/auto-scenario-config-for-ember-test.js
+++ b/test/auto-scenario-config-for-ember-test.js
@@ -79,4 +79,25 @@ describe('lib/auto-scenario-config-for-ember', () => {
       expect(config.scenarios).toMatchSnapshot();
     });
   });
+  test('returns only requested versions', () => {
+    let availableVersions = [
+      '2.11.0',
+      '2.12.0',
+      '2.12.2',
+      '2.13.0',
+      '2.18.0',
+      '3.0.0',
+      '3.1.0',
+      '3.1.1',
+    ];
+
+    return autoScenarioConfigForEmber({
+      onlyVersionCompatibility: true,
+      versionCompatibility: { ember: '2.11.0 - 2.12.7 || ~ 3.1.0 || ^2.18.0' },
+      availableVersions,
+      getChannelURL: fakeGetChannelUrl,
+    }).then((config) => {
+      expect(config.scenarios).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a new option "onlyVersionCompatibility" for generateConfig function. When it is true generateConfig will return just the requested versions. Currently, it returns the requested versions plus beta, canary and release.

It was done because of the following PR:
https://github.com/mansona/ember-try/pull/1