### PR TITLE
add default overrides for generated beta and canary configs

### DIFF
--- a/lib/auto-scenario-config-for-ember.js
+++ b/lib/auto-scenario-config-for-ember.js
@@ -33,9 +33,6 @@ async function generateScenariosFromSemver(semverStatements, availableVersions) 
             devDependencies: {
               'ember-source': versionNum,
             },
-            overrides: {
-              'ember-source': '$ember-source',
-            },
           },
         };
       } else {
@@ -88,9 +85,6 @@ async function generateBaseScenarios(_getChannelURL = getChannelURL) {
       npm: {
         devDependencies: {
           'ember-source': release,
-        },
-        overrides: {
-          'ember-source': '$ember-source',
         },
       },
     },

--- a/lib/auto-scenario-config-for-ember.js
+++ b/lib/auto-scenario-config-for-ember.js
@@ -33,6 +33,9 @@ async function generateScenariosFromSemver(semverStatements, availableVersions) 
             devDependencies: {
               'ember-source': versionNum,
             },
+            overrides: {
+              'ember-source': '$ember-source',
+            },
           },
         };
       } else {
@@ -63,6 +66,9 @@ async function generateBaseScenarios(_getChannelURL = getChannelURL) {
         devDependencies: {
           'ember-source': beta,
         },
+        overrides: {
+          'ember-source': '$ember-source',
+        },
       },
     },
     {
@@ -72,6 +78,9 @@ async function generateBaseScenarios(_getChannelURL = getChannelURL) {
         devDependencies: {
           'ember-source': canary,
         },
+        overrides: {
+          'ember-source': '$ember-source',
+        },
       },
     },
     {
@@ -79,6 +88,9 @@ async function generateBaseScenarios(_getChannelURL = getChannelURL) {
       npm: {
         devDependencies: {
           'ember-source': release,
+        },
+        overrides: {
+          'ember-source': '$ember-source',
         },
       },
     },

--- a/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
+++ b/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
@@ -38,9 +38,6 @@ Array [
       "devDependencies": Object {
         "ember-source": "https://emberjs.example.com/release-1234.tgz",
       },
-      "overrides": Object {
-        "ember-source": "$ember-source",
-      },
     },
   },
   Object {
@@ -48,9 +45,6 @@ Array [
     "npm": Object {
       "devDependencies": Object {
         "ember-source": "2.11.0",
-      },
-      "overrides": Object {
-        "ember-source": "$ember-source",
       },
     },
   },
@@ -60,9 +54,6 @@ Array [
       "devDependencies": Object {
         "ember-source": "2.12.2",
       },
-      "overrides": Object {
-        "ember-source": "$ember-source",
-      },
     },
   },
   Object {
@@ -71,9 +62,6 @@ Array [
       "devDependencies": Object {
         "ember-source": "2.18.0",
       },
-      "overrides": Object {
-        "ember-source": "$ember-source",
-      },
     },
   },
   Object {
@@ -81,9 +69,6 @@ Array [
     "npm": Object {
       "devDependencies": Object {
         "ember-source": "3.1.1",
-      },
-      "overrides": Object {
-        "ember-source": "$ember-source",
       },
     },
   },

--- a/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
+++ b/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
@@ -15,6 +15,9 @@ Array [
       "devDependencies": Object {
         "ember-source": "https://emberjs.example.com/beta-1234.tgz",
       },
+      "overrides": Object {
+        "ember-source": "$ember-source",
+      },
     },
   },
   Object {
@@ -24,6 +27,9 @@ Array [
       "devDependencies": Object {
         "ember-source": "https://emberjs.example.com/canary-1234.tgz",
       },
+      "overrides": Object {
+        "ember-source": "$ember-source",
+      },
     },
   },
   Object {
@@ -31,6 +37,9 @@ Array [
     "npm": Object {
       "devDependencies": Object {
         "ember-source": "https://emberjs.example.com/release-1234.tgz",
+      },
+      "overrides": Object {
+        "ember-source": "$ember-source",
       },
     },
   },
@@ -40,6 +49,9 @@ Array [
       "devDependencies": Object {
         "ember-source": "2.11.0",
       },
+      "overrides": Object {
+        "ember-source": "$ember-source",
+      },
     },
   },
   Object {
@@ -47,6 +59,9 @@ Array [
     "npm": Object {
       "devDependencies": Object {
         "ember-source": "2.12.2",
+      },
+      "overrides": Object {
+        "ember-source": "$ember-source",
       },
     },
   },
@@ -56,6 +71,9 @@ Array [
       "devDependencies": Object {
         "ember-source": "2.18.0",
       },
+      "overrides": Object {
+        "ember-source": "$ember-source",
+      },
     },
   },
   Object {
@@ -63,6 +81,9 @@ Array [
     "npm": Object {
       "devDependencies": Object {
         "ember-source": "3.1.1",
+      },
+      "overrides": Object {
+        "ember-source": "$ember-source",
       },
     },
   },

--- a/test/auto-scenario-config-for-ember-test.js
+++ b/test/auto-scenario-config-for-ember-test.js
@@ -28,6 +28,9 @@ describe('lib/auto-scenario-config-for-ember', () => {
             devDependencies: {
               'ember-source': 'https://emberjs.example.com/beta-1234.tgz',
             },
+            overrides: {
+              'ember-source': '$ember-source',
+            },
           },
         },
         {
@@ -37,6 +40,9 @@ describe('lib/auto-scenario-config-for-ember', () => {
             devDependencies: {
               'ember-source': 'https://emberjs.example.com/canary-1234.tgz',
             },
+            overrides: {
+              'ember-source': '$ember-source',
+            },
           },
         },
         {
@@ -45,6 +51,9 @@ describe('lib/auto-scenario-config-for-ember', () => {
             devDependencies: {
               'ember-source': 'https://emberjs.example.com/release-1234.tgz',
             },
+            overrides: {
+              'ember-source': '$ember-source',
+            },
           },
         },
         {
@@ -52,6 +61,9 @@ describe('lib/auto-scenario-config-for-ember', () => {
           npm: {
             devDependencies: {
               'ember-source': '2.18.0',
+            },
+            overrides: {
+              'ember-source': '$ember-source',
             },
           },
         },

--- a/test/auto-scenario-config-for-ember-test.js
+++ b/test/auto-scenario-config-for-ember-test.js
@@ -51,9 +51,6 @@ describe('lib/auto-scenario-config-for-ember', () => {
             devDependencies: {
               'ember-source': 'https://emberjs.example.com/release-1234.tgz',
             },
-            overrides: {
-              'ember-source': '$ember-source',
-            },
           },
         },
         {
@@ -61,9 +58,6 @@ describe('lib/auto-scenario-config-for-ember', () => {
           npm: {
             devDependencies: {
               'ember-source': '2.18.0',
-            },
-            overrides: {
-              'ember-source': '$ember-source',
             },
           },
         },


### PR DESCRIPTION
I'm in the process of getting https://github.com/ember-cli/ember-try/pull/920 to pass and I came across a curious problem. All of the auto-generated scenarios all need to have an override to make npm happy 😫 

This PR adds that override and makes sure that tests pass 👍 