### PR TITLE
Downgrade ember-cli if ember-source <= 3.28 is gonna be used with ember-cli 5+

### DIFF
--- a/lib/auto-scenario-config-for-ember.js
+++ b/lib/auto-scenario-config-for-ember.js
@@ -8,7 +8,11 @@ const firstEmberSourceVersion = '2.11.0';
 module.exports = async function generateConfig(options) {
   let [base, semver] = await Promise.all([
     generateBaseScenarios(options.getChannelURL),
-    generateScenariosFromSemver(options.versionCompatibility, options.availableVersions),
+    generateScenariosFromSemver(
+      options.versionCompatibility,
+      options.availableVersions,
+      options.project
+    ),
   ]);
 
   return {
@@ -16,7 +20,7 @@ module.exports = async function generateConfig(options) {
   };
 };
 
-async function generateScenariosFromSemver(semverStatements, availableVersions) {
+async function generateScenariosFromSemver(semverStatements, availableVersions, project) {
   let statement = semverStatements.ember;
 
   let possibleVersions = availableVersions ? availableVersions : await getEmberVersions();
@@ -27,7 +31,7 @@ async function generateScenariosFromSemver(semverStatements, availableVersions) 
       let versionNum = semver.clean(version);
 
       if (semver.gte(versionNum, firstEmberSourceVersion)) {
-        return {
+        const scenario = {
           name: `ember-${versionNum}`,
           npm: {
             devDependencies: {
@@ -35,6 +39,20 @@ async function generateScenariosFromSemver(semverStatements, availableVersions) 
             },
           },
         };
+
+        // If the app has ember-source < 4.0.0 and ember-cli >= 5.0.0, we need to add ember-cli < 5.0.0 as a dependency
+        // because ember-cli 5.0.0+ requires ember-source 4.0.0+.
+        if (
+          semver.lt(versionNum, '4.0.0') &&
+          project &&
+          project.dependencies &&
+          project.dependencies()['ember-cli'] &&
+          semver.gte(semver.minVersion(project.dependencies()['ember-cli']), '5.0.0')
+        ) {
+          scenario.npm.devDependencies['ember-cli'] = '~4.12.0';
+        }
+
+        return scenario;
       } else {
         return null;
       }

--- a/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
+++ b/test/__snapshots__/auto-scenario-config-for-ember-test.js.snap
@@ -1,5 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/auto-scenario-config-for-ember dependency version heuristics using ember-source < 4.0 adds ember-cli as dependency 1`] = `
+Array [
+  Object {
+    "name": "default",
+    "npm": Object {
+      "devDependencies": Object {},
+    },
+  },
+  Object {
+    "allowedToFail": true,
+    "name": "ember-beta",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "https://emberjs.example.com/beta-1234.tgz",
+      },
+    },
+  },
+  Object {
+    "allowedToFail": true,
+    "name": "ember-canary",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "https://emberjs.example.com/canary-1234.tgz",
+      },
+    },
+  },
+  Object {
+    "name": "ember-release",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "https://emberjs.example.com/release-1234.tgz",
+      },
+    },
+  },
+  Object {
+    "name": "ember-3.28.0",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-cli": "~4.12.0",
+        "ember-source": "3.28.0",
+      },
+    },
+  },
+]
+`;
+
+exports[`lib/auto-scenario-config-for-ember dependency version heuristics using ember-source < 4.0 with ember-cli < 5.0 does not add ember-cli as dependency 1`] = `
+Array [
+  Object {
+    "name": "default",
+    "npm": Object {
+      "devDependencies": Object {},
+    },
+  },
+  Object {
+    "allowedToFail": true,
+    "name": "ember-beta",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "https://emberjs.example.com/beta-1234.tgz",
+      },
+    },
+  },
+  Object {
+    "allowedToFail": true,
+    "name": "ember-canary",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "https://emberjs.example.com/canary-1234.tgz",
+      },
+    },
+  },
+  Object {
+    "name": "ember-release",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "https://emberjs.example.com/release-1234.tgz",
+      },
+    },
+  },
+  Object {
+    "name": "ember-3.28.0",
+    "npm": Object {
+      "devDependencies": Object {
+        "ember-source": "3.28.0",
+      },
+    },
+  },
+]
+`;
+
 exports[`lib/auto-scenario-config-for-ember works with complex semver statement 1`] = `
 Array [
   Object {

--- a/test/auto-scenario-config-for-ember-test.js
+++ b/test/auto-scenario-config-for-ember-test.js
@@ -79,4 +79,42 @@ describe('lib/auto-scenario-config-for-ember', () => {
       expect(config.scenarios).toMatchSnapshot();
     });
   });
+
+  describe('dependency version heuristics', () => {
+    test('using ember-source < 4.0 adds ember-cli as dependency', async () => {
+      const project = {
+        dependencies() {
+          return {
+            'ember-cli': '^5.1.0',
+          };
+        },
+      };
+
+      const config = await autoScenarioConfigForEmber({
+        versionCompatibility: { ember: '3.28.0' },
+        getChannelURL: fakeGetChannelUrl,
+        project,
+      });
+
+      expect(config.scenarios).toMatchSnapshot();
+    });
+
+    test('using ember-source < 4.0 with ember-cli < 5.0 does not add ember-cli as dependency', async () => {
+      const project = {
+        dependencies() {
+          return {
+            'ember-cli': '^4.12.1',
+          };
+        },
+      };
+
+      const config = await autoScenarioConfigForEmber({
+        versionCompatibility: { ember: '3.28.0' },
+        getChannelURL: fakeGetChannelUrl,
+        project,
+      });
+
+      expect(config.scenarios).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
This is continuation of https://github.com/ember-cli/ember-try-config/pull/191 .

It's not a complete solution. Please consider it to be a first iteration.